### PR TITLE
Replace references of articulate app to attendees

### DIFF
--- a/Labs/Logging_Scale_HA/lab_logging_scale_ha.adoc
+++ b/Labs/Logging_Scale_HA/lab_logging_scale_ha.adoc
@@ -115,7 +115,7 @@ $ cf app attendees
 . Kill the app. Press the Kill button!
 . Check the state of the app through the cf CLI.
 ----
-$ cf app articulate
+$ cf app attendees
 ----
 Sample output below (notice the requested state vs actual state). In this case, Pivotal Cloud Foundry had already detected the failure and is starting a new instance.
 ----
@@ -139,18 +139,18 @@ buildpack:         container-security-provider=1.5.0_RELEASE
 #2   running    2017-08-10T00:30:32Z   2.1%   408.8M of 768M   161.9M of 1G
 ----
 Repeat this command as necessary until `state = running`.
-. In your browser, Refresh the articulate application.
+. In your browser, Refresh the attendees application.
 The app is back up!
 
 A new, healthy app instance has been automatically provisioned to replace the failing one.
 
 . View which instance was killed.
 ----
-$ cf events articulate
+$ cf events attendees
 ----
-. Scale articulate back to our original settings.
+. Scale attendees back to our original settings.
 ----
-$ cf scale articulate -i 1
+$ cf scale attendees -i 1
 ----
 
 === Questions


### PR DESCRIPTION
No sure why this labs mention a `articulate` app when it is all about the `attendees`. Old app I guess.